### PR TITLE
- eliminate 2 allocations from EachKey

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -370,11 +370,19 @@ func sameTree(p1, p2 []string) bool {
 	return true
 }
 
+const stackArraySize = 128
+
 func EachKey(data []byte, cb func(int, []byte, ValueType, error), paths ...[]string) int {
 	var x struct{}
-	pathFlags := make([]bool, len(paths))
+	//pathFlags := make([]bool, len(paths))
 	var level, pathsMatched, i int
 	ln := len(data)
+
+	pathFlags := make([]bool, stackArraySize)[:]
+	if len(paths) > cap(pathFlags) {
+		pathFlags = make([]bool, len(paths))[:]
+	}
+	pathFlags = pathFlags[0:len(paths)]
 
 	var maxPath int
 	for _, p := range paths {
@@ -383,7 +391,11 @@ func EachKey(data []byte, cb func(int, []byte, ValueType, error), paths ...[]str
 		}
 	}
 
-	pathsBuf := make([]string, maxPath)
+	pathsBuf := make([]string, stackArraySize)[:]
+	if maxPath > cap(pathsBuf) {
+		pathsBuf = make([]string, maxPath)[:]
+	}
+	pathsBuf = pathsBuf[0:maxPath]
 
 	for i < ln {
 		switch data[i] {
@@ -657,7 +669,6 @@ func calcAllocateSpace(keys []string, setValue []byte, comma, object bool) int {
 			lk += len(keys[0]) + 3
 		}
 	}
-
 
 	lk += len(setValue)
 	for i := 1; i < len(keys); i++ {


### PR DESCRIPTION
**Description**: 
Eliminate allocations in EachKey()

**Benchmark before change**:
```
BenchmarkEachKey
BenchmarkEachKey-8
  308006	      3885 ns/op	     272 B/op	       4 allocs/op
PASS
```

**Benchmark after change**:
```
BenchmarkEachKey
BenchmarkEachKey-8
  333666	      3674 ns/op	       8 B/op	       1 allocs/op
PASS
```

For running benchmarks use:
```
go test -test.benchmem -bench JsonParser ./benchmark/ -benchtime 5s -v
# OR
make bench (runs inside docker)
```

For this I used this to benchmark:
```
func BenchmarkEachKey(b *testing.B) {
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		var id string
		var bidId string
		var bidImpId string
		var bidPrice string
		var bidAdm string
		var cur string
		var foo string

		bodyBytes := stringHelper.StringAsBytes(BidResponse_Banner)

		jsonparser.EachKey(bodyBytes, func(idx int, value []byte, vt jsonparser.ValueType, err error) {
			switch idx {
			case 0:
				id = stringHelper.BytesAsString(value)
			case 1:
				bidId = stringHelper.BytesAsString(value)
			case 2:
				bidImpId = stringHelper.BytesAsString(value)
			case 3:
				bidPrice = stringHelper.BytesAsString(value)
			case 4:
				bidAdm = stringHelper.BytesAsString(value)
			case 5:
				cur = stringHelper.BytesAsString(value)
			case 6:
				foo = stringHelper.BytesAsString(value)
			}
		},
			[][]string{
				{"id"},
				{"seatbid", "[0]", "bid", "[0]", "id"},
				{"seatbid", "[0]", "bid", "[0]", "impid"},
				{"seatbid", "[0]", "bid", "[0]", "price"},
				{"seatbid", "[0]", "bid", "[0]", "adm"},
				{"cur"},
				{"foo"},
			}...,
		)

		if "9f3701ef-1d8a-4b67-a601-e9a1a2fbcb7c" != id ||
			"0" != bidId ||
			"1" != bidImpId ||
			"0.35258" != bidPrice ||
			`some \"html\" code\nnext line` != bidAdm ||
			"USD" != cur ||
			"" != foo {
			panic("ack")
		}
	}

}

const BidResponse_Banner = `
{
	"id":"9f3701ef-1d8a-4b67-a601-e9a1a2fbcb7c",
	"seatbid":[
	   {
		  "bid":[
			 {
				"id":"0",
				"adomain":[
				   "someurl.com",
				   "someotherurl.com"
				],
				"impid":"1",
				"price":0.35258,
				"adm":"some \"html\" code\nnext line",
				"w":300,
				"h":250
			 }
		  ]
	   }
	],
	"cur":"USD"
}
`

var BidResponse_Banner_Paths [][]string = [][]string{
	{"id"},
	{"seatbid", "[0]", "bid", "[0]", "id"},
	{"seatbid", "[0]", "bid", "[0]", "impid"},
	{"seatbid", "[0]", "bid", "[0]", "price"},
	{"seatbid", "[0]", "bid", "[0]", "adm"},
	{"cur"},
	{"foo"},
}
```